### PR TITLE
allow remapping of first two buttons

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ version_date='2020-05-25'
 # The DBus API version of ratbagd that we are compatible with. Anything
 # higher or lower will not be compatible so make sure you bumpt that to the
 # latest released ratbagd version whenever a piper release is made.
-ratbagd_api_version = 1
+ratbagd_api_version = 2
 
 
 # Dependencies

--- a/piper/buttondialog.py
+++ b/piper/buttondialog.py
@@ -5,7 +5,7 @@ import sys
 from gettext import gettext as _
 
 from .gi_composites import GtkTemplate
-from .ratbagd import RatbagdButton, RatbagdMacro
+from .ratbagd import RatbagdButton, RatbagdMacro, RatbagDeviceType
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -71,17 +71,19 @@ class ButtonDialog(Gtk.Dialog):
     search_entry = GtkTemplate.Child()
     search_bar = GtkTemplate.Child()
 
-    def __init__(self, ratbagd_button, buttons, *args, **kwargs):
+    def __init__(self, ratbagd_button, buttons, device_type, *args, **kwargs):
         """Instantiates a new ButtonDialog.
 
         @param ratbagd_button The button to configure, as ratbagd.RatbagdButton.
         @param buttons The buttons on this device, as [ratbagd.RatbagdButton].
+        @param devicetype The type of this device, as ratbagd.RatbagDeviceType.
         """
         Gtk.Dialog.__init__(self, *args, **kwargs)
         self.init_template()
         self._grab_pointer = None
         self._current_macro = None
         self._button = ratbagd_button
+        self._device_type = device_type
         self._action_type = self._button.action_type
         if self._action_type == RatbagdButton.ActionType.BUTTON:
             self._mapping = self._button.mapping
@@ -95,7 +97,7 @@ class ButtonDialog(Gtk.Dialog):
         self._init_ui(buttons)
 
     def _init_ui(self, buttons):
-        if self._button.index in [0, 1]:
+        if self._device_type is RatbagDeviceType.MOUSE and self._button.index in [0, 1]:
             self._init_primary_buttons_ui()
         else:
             self._init_other_buttons_ui(buttons)

--- a/piper/buttonspage.py
+++ b/piper/buttonspage.py
@@ -90,7 +90,8 @@ class ButtonsPage(Gtk.Box):
         # Presents the ButtonDialog to configure the mouse button corresponding
         # to the clicked button.
         buttons = self._find_active_profile().buttons
-        dialog = ButtonDialog(ratbagd_button, buttons,
+        device_type = self._device.device_type
+        dialog = ButtonDialog(ratbagd_button, buttons, device_type,
                               title=_("Configure button {}").format(ratbagd_button.index),
                               use_header_bar=True,
                               transient_for=self.get_toplevel())

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -62,6 +62,22 @@ class RatbagErrorCode(IntEnum):
     IMPLEMENTATION = -1004
 
 
+class RatbagDeviceType(IntEnum):
+    """DeviceType property specified in the .device files"""
+
+    """There was no DeviceType specified for this device"""
+    UNSPECIFIED = 0
+
+    """Device is specified as anything other than a mouse or a keyboard"""
+    OTHER = 1
+
+    """Device is specified as a mouse"""
+    MOUSE = 2
+
+    """Device is specified as a keyboard"""
+    KEYBOARD = 3
+
+
 class RatbagdIncompatible(Exception):
     """ratbagd is incompatible with this client"""
     def __init__(self, ratbagd_version, required_version):
@@ -348,6 +364,11 @@ class RatbagdDevice(_RatbagdDBus):
     def name(self):
         """The device name, usually provided by the kernel."""
         return self._get_dbus_property("Name")
+
+    @GObject.Property
+    def device_type(self):
+        """The device type, see RatbagDeviceType"""
+        return RatbagDeviceType(self._get_dbus_property("DeviceType"))
 
     @GObject.Property
     def profiles(self):


### PR DESCRIPTION
on non mouse devices the first two buttons can now be remapped. uses the new DeviceType property exposed by ratbagd.

Signed-off-by: Julian Kandlhofer <julian.kandlhofer@gmail.com>